### PR TITLE
Add OperationType to OperationHandle

### DIFF
--- a/Sources/DropboxFileProvider.swift
+++ b/Sources/DropboxFileProvider.swift
@@ -177,7 +177,7 @@ extension DropboxFileProvider: FileProviderOperations {
             completionHandler?(error)
         }) 
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: operation.baseType)
     }
     
     public func copyItem(localFile: URL, to toPath: String, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
@@ -219,7 +219,7 @@ extension DropboxFileProvider: FileProviderOperations {
         })
         task.taskDescription = dictionaryToJSON(["type": "Copy" as NSString, "source": path as NSString, "dest": destURL.absoluteString as NSString])
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: .copy)
     }
 }
 
@@ -250,7 +250,7 @@ extension DropboxFileProvider: FileProviderReadWrite {
             completionHandler(data, error)
         })
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: .contents)
     }
     
     public func writeContents(path: String, contents data: Data, atomically: Bool = false, completionHandler: SimpleCompletionHandler) -> OperationHandle? {

--- a/Sources/DropboxHelper.swift
+++ b/Sources/DropboxHelper.swift
@@ -123,7 +123,7 @@ internal extension DropboxFileProvider {
         }
         task.taskDescription = dictionaryToJSON(dic)
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: operation.baseType)
     }
     
     func search(_ startPath: String = "", query: String, start: Int = 0, maxResultPerPage: Int = 25, maxResults: Int = -1, foundItem:@escaping ((_ file: DropboxFileObject) -> Void), completionHandler: @escaping ((_ error: Error?) -> Void)) {

--- a/Sources/FileProvider.swift
+++ b/Sources/FileProvider.swift
@@ -282,6 +282,11 @@ public protocol ExtendedFileProvider: FileProvider {
     func propertiesOfFile(path: String, completionHandler: @escaping ((_ propertiesDictionary: [String: Any], _ keys: [String], _ error: Error?) -> Void))
 }
 
+@objc
+public enum OperationType: Int {
+    case contents, create, copy, move, modify, remove, link
+}
+
 public enum FileOperationType: CustomStringConvertible {
     case create (path: String)
     case copy   (source: String, destination: String)
@@ -289,6 +294,23 @@ public enum FileOperationType: CustomStringConvertible {
     case modify (path: String)
     case remove (path: String)
     case link   (link: String, target: String)
+
+    public var baseType: OperationType {
+        switch self {
+        case .create:
+            return .create
+        case .copy:
+            return .copy
+        case .move:
+            return .move
+        case .modify:
+            return .modify
+        case .remove:
+            return .remove
+        case .link:
+            return .link
+        }
+    }
     
     public var description: String {
         switch self {
@@ -315,6 +337,7 @@ public enum FileOperationType: CustomStringConvertible {
 
 @objc
 public protocol OperationHandle {
+    var type: OperationType { get }
     var progress: Float { get }
     var bytesSoFar: Int64 { get }
     var totalBytes: Int64 { get }

--- a/Sources/FileProvider.swift
+++ b/Sources/FileProvider.swift
@@ -337,7 +337,7 @@ public enum FileOperationType: CustomStringConvertible {
 
 @objc
 public protocol OperationHandle {
-    var type: OperationType { get }
+    var operationType: OperationType { get }
     var progress: Float { get }
     var bytesSoFar: Int64 { get }
     var totalBytes: Int64 { get }

--- a/Sources/RemoteSession.swift
+++ b/Sources/RemoteSession.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 open class RemoteOperationHandle: OperationHandle {
-    
+    public var type: OperationType
+
     internal var tasks: [Weak<URLSessionTask>]
     
     private var _inProgress = false
@@ -17,8 +18,9 @@ open class RemoteOperationHandle: OperationHandle {
         return _inProgress
     }
     
-    init(tasks: [URLSessionTask]) {
+    init(tasks: [URLSessionTask], operation type: OperationType) {
         self.tasks = tasks.map { Weak<URLSessionTask>($0) }
+        self.type = type
         _inProgress = true
     }
     

--- a/Sources/RemoteSession.swift
+++ b/Sources/RemoteSession.swift
@@ -9,15 +9,15 @@
 import Foundation
 
 open class RemoteOperationHandle: OperationHandle {
-    public var type: OperationType
+    open private(set) var operationType: OperationType
 
     internal var tasks: [Weak<URLSessionTask>]
     
     open private(set) var inProgress = false
     
-    init(tasks: [URLSessionTask], operation type: OperationType) {
+    init(tasks: [URLSessionTask], operation operationType: OperationType) {
         self.tasks = tasks.map { Weak<URLSessionTask>($0) }
-        self.type = type
+        self.operationType = operationType
         inProgress = true
     }
     

--- a/Sources/RemoteSession.swift
+++ b/Sources/RemoteSession.swift
@@ -13,15 +13,12 @@ open class RemoteOperationHandle: OperationHandle {
 
     internal var tasks: [Weak<URLSessionTask>]
     
-    private var _inProgress = false
-    open var inProgress: Bool {
-        return _inProgress
-    }
+    open private(set) var inProgress = false
     
     init(tasks: [URLSessionTask], operation type: OperationType) {
         self.tasks = tasks.map { Weak<URLSessionTask>($0) }
         self.type = type
-        _inProgress = true
+        inProgress = true
     }
     
     internal func add(task: URLSessionTask) {
@@ -62,7 +59,7 @@ open class RemoteOperationHandle: OperationHandle {
         for taskbox in tasks {
             taskbox.value?.cancel()
         }
-        _inProgress = false
+        inProgress = false
     }
 }
 

--- a/Sources/WebDAVFileProvider.swift
+++ b/Sources/WebDAVFileProvider.swift
@@ -171,7 +171,7 @@ extension WebDAVFileProvider: FileProviderOperations {
             self.delegateNotify(.create(path: (atPath as NSString).appendingPathComponent(folderName) + "/"), error: responseError ?? error)
         }) 
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: .create)
     }
     
     @discardableResult
@@ -192,7 +192,7 @@ extension WebDAVFileProvider: FileProviderOperations {
         }) 
         task.taskDescription = dictionaryToJSON(["type": "Create" as NSString, "source": (path as NSString).appendingPathComponent(fileAttribs.name) as NSString])
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: .create)
     }
     
     @discardableResult
@@ -242,7 +242,7 @@ extension WebDAVFileProvider: FileProviderOperations {
             completionHandler?(error)
         }) 
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: move ? .move : .copy)
     }
     
     @discardableResult
@@ -271,7 +271,7 @@ extension WebDAVFileProvider: FileProviderOperations {
             completionHandler?(error)
         }) 
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: .remove)
     }
     
     @discardableResult
@@ -292,7 +292,7 @@ extension WebDAVFileProvider: FileProviderOperations {
         }) 
         task.taskDescription = dictionaryToJSON(["type": "Copy" as NSString, "source": localFile.absoluteString as NSString, "dest": toPath as NSString])
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: .copy)
     }
     
     @discardableResult
@@ -319,7 +319,7 @@ extension WebDAVFileProvider: FileProviderOperations {
         }) 
         task.taskDescription = dictionaryToJSON(["type": "Copy" as NSString, "source": path as NSString, "dest": toLocalURL.absoluteString as NSString])
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: .copy)
     }
 }
 
@@ -347,7 +347,7 @@ extension WebDAVFileProvider: FileProviderReadWrite {
             completionHandler(data, responseError ?? error)
         }) 
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: .contents)
     }
     
     @discardableResult
@@ -377,7 +377,7 @@ extension WebDAVFileProvider: FileProviderReadWrite {
         }) 
         task.taskDescription = dictionaryToJSON(["type": "Modify" as NSString, "source": path as NSString])
         task.resume()
-        return RemoteOperationHandle(tasks: [task])
+        return RemoteOperationHandle(tasks: [task], operation: .create)
     }
     
     public func searchFiles(path: String, recursive: Bool, query: String, foundItemHandler: ((FileObject) -> Void)?, completionHandler: @escaping ((_ files: [FileObject], _ error: Error?) -> Void)) {


### PR DESCRIPTION
I feel it would be useful to know what type of operation handle you have in case you have a pending transaction. This way you don't perform additional operations that could compromise the pending operation.

Additionally, properties can have a different access level for the set mutator (i.e. `open private(set) var myVar`).