### PR TITLE
Fixes #15, FileObject.fileType always returns nil.

### DIFF
--- a/Sources/FileProvider.swift
+++ b/Sources/FileProvider.swift
@@ -370,10 +370,7 @@ open class FileObject {
     
     open internal(set) var fileType: URLFileResourceType? {
         get {
-            guard let typeString = allValues[URLResourceKey.fileResourceTypeKey.rawValue] as? String else {
-                return nil
-            }
-            return URLFileResourceType(rawValue: typeString)
+            return allValues[URLResourceKey.fileResourceTypeKey.rawValue] as? URLFileResourceType
         }
         set {
             allValues[URLResourceKey.fileResourceTypeKey.rawValue] = newValue


### PR DESCRIPTION
The `fileType` is already being stored as a `URLFileResourceType` via the setter.