### PR TITLE
Overwrite param added to copyItem + minor bugfix and improvements

### DIFF
--- a/Sources/DropboxFileProvider.swift
+++ b/Sources/DropboxFileProvider.swift
@@ -174,17 +174,12 @@ extension DropboxFileProvider: FileProviderOperations {
         return RemoteOperationHandle(operationType: operation, tasks: [task])
     }
     
-    public func copyItem(localFile: URL, to toPath: String, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
+    public func copyItem(localFile: URL, to toPath: String, overwrite: Bool = false, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
         let opType = FileOperationType.copy(source: localFile.absoluteString, destination: toPath)
         guard fileOperationDelegate?.fileProvider(self, shouldDoOperation: opType) ?? true == true else {
             return nil
         }
-        guard let data = try? Data(contentsOf: localFile) else {
-            let error = throwError(localFile.absoluteString, code: URLError.fileDoesNotExist as FoundationErrorEnum)
-            completionHandler?(error)
-            return nil
-        }
-        return upload_simple(toPath, data: data, overwrite: true, operation: opType, completionHandler: completionHandler)
+        return upload_simple(toPath, localFile: localFile, overwrite: overwrite, operation: opType, completionHandler: completionHandler)
     }
     
     public func copyItem(path: String, toLocalURL destURL: URL, completionHandler: SimpleCompletionHandler) -> OperationHandle? {

--- a/Sources/DropboxFileProvider.swift
+++ b/Sources/DropboxFileProvider.swift
@@ -174,7 +174,7 @@ extension DropboxFileProvider: FileProviderOperations {
         return RemoteOperationHandle(operationType: operation, tasks: [task])
     }
     
-    public func copyItem(localFile: URL, to toPath: String, overwrite: Bool = false, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
+    public func copyItem(localFile: URL, to toPath: String, overwrite: Bool, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
         let opType = FileOperationType.copy(source: localFile.absoluteString, destination: toPath)
         guard fileOperationDelegate?.fileProvider(self, shouldDoOperation: opType) ?? true == true else {
             return nil

--- a/Sources/DropboxHelper.swift
+++ b/Sources/DropboxHelper.swift
@@ -97,15 +97,6 @@ internal extension DropboxFileProvider {
         task.resume()
     }
     
-    var uploadDateFormatter : DateFormatter
-    {
-        let fm = DateFormatter()
-        fm.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"
-        fm.timeZone = TimeZone(identifier:"UTC")
-        fm.locale = Locale(identifier:"en_US_POSIX")
-        return fm
-    }
-    
     func upload_simple(_ targetPath: String, data: Data, modifiedDate: Date = Date(), overwrite: Bool, operation: FileOperationType, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
         assert(data.count < 150*1024*1024, "Maximum size of allowed size to upload is 150MB")
         var requestDictionary = [String: Any]()
@@ -113,8 +104,7 @@ internal extension DropboxFileProvider {
         url = URL(string: "https://content.dropboxapi.com/2/files/upload")!
         requestDictionary["path"] = correctPath(targetPath) as NSString?
         requestDictionary["mode"] = (overwrite ? "overwrite" : "add") as NSString
-        let dateFormatter = uploadDateFormatter
-        requestDictionary["client_modified"] = dateFormatter.string(from: modifiedDate)
+        requestDictionary["client_modified"] = string(from:modifiedDate)
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(credential?.password ?? "")", forHTTPHeaderField: "Authorization")
@@ -140,8 +130,7 @@ internal extension DropboxFileProvider {
         url = URL(string: "https://content.dropboxapi.com/2/files/upload")!
         requestDictionary["path"] = correctPath(targetPath) as NSString?
         requestDictionary["mode"] = (overwrite ? "overwrite" : "add") as NSString
-        let dateFormatter = uploadDateFormatter
-        requestDictionary["client_modified"] = dateFormatter.string(from: modifiedDate)
+        requestDictionary["client_modified"] = string(from:modifiedDate)
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(credential?.password ?? "")", forHTTPHeaderField: "Authorization")

--- a/Sources/FileProvider.swift
+++ b/Sources/FileProvider.swift
@@ -107,9 +107,8 @@ public protocol FileProviderOperations: FileProviderBasic {
     func copyItem(path: String, to: String, overwrite: Bool, completionHandler: SimpleCompletionHandler) -> OperationHandle?
     @discardableResult
     func removeItem(path: String, completionHandler: SimpleCompletionHandler) -> OperationHandle?
-    
     @discardableResult
-    func copyItem(localFile: URL, to: String, completionHandler: SimpleCompletionHandler) -> OperationHandle?
+    func copyItem(localFile: URL, to: String, overwrite: Bool, completionHandler: SimpleCompletionHandler) -> OperationHandle?
     @discardableResult
     func copyItem(path: String, toLocalURL: URL, completionHandler: SimpleCompletionHandler) -> OperationHandle?
 }

--- a/Sources/FileProvider.swift
+++ b/Sources/FileProvider.swift
@@ -120,6 +120,11 @@ extension FileProviderOperations {
     }
     
     @discardableResult
+    func copyItem(localFile: URL, to: String, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
+        return self.copyItem(localFile: localFile, to: to, overwrite: false, completionHandler: completionHandler)
+    }
+    
+    @discardableResult
     public func copyItem(path: String, to: String, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
         return self.copyItem(path: path, to: to, overwrite: false, completionHandler: completionHandler)
     }
@@ -290,6 +295,15 @@ extension FileProviderBasic {
         }
         return nil
     }
+    
+    public func string(from date:Date) -> String {
+        let fm = DateFormatter()
+        fm.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"
+        fm.timeZone = TimeZone(identifier:"UTC")
+        fm.locale = Locale(identifier:"en_US_POSIX")
+        return fm.string(from:date)
+    }
+    
 }
 
 public protocol ExtendedFileProvider: FileProvider {

--- a/Sources/FileProvider.swift
+++ b/Sources/FileProvider.swift
@@ -108,6 +108,8 @@ public protocol FileProviderOperations: FileProviderBasic {
     @discardableResult
     func removeItem(path: String, completionHandler: SimpleCompletionHandler) -> OperationHandle?
     @discardableResult
+    func copyItem(localFile: URL, to: String, completionHandler: SimpleCompletionHandler) -> OperationHandle?
+    @discardableResult
     func copyItem(localFile: URL, to: String, overwrite: Bool, completionHandler: SimpleCompletionHandler) -> OperationHandle?
     @discardableResult
     func copyItem(path: String, toLocalURL: URL, completionHandler: SimpleCompletionHandler) -> OperationHandle?

--- a/Sources/LocalFileProvider.swift
+++ b/Sources/LocalFileProvider.swift
@@ -182,7 +182,7 @@ open class LocalFileProvider: FileProvider, FileProviderMonitor {
     }
     
     @discardableResult
-    open func copyItem(localFile: URL, to toPath: String, overwrite: Bool = false, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
+    open func copyItem(localFile: URL, to toPath: String, overwrite: Bool, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
         // TODO: Make use of overwrite parameter
         let opType = FileOperationType.copy(source: localFile.absoluteString, destination: toPath)
         operation_queue.async {

--- a/Sources/LocalFileProvider.swift
+++ b/Sources/LocalFileProvider.swift
@@ -182,7 +182,8 @@ open class LocalFileProvider: FileProvider, FileProviderMonitor {
     }
     
     @discardableResult
-    open func copyItem(localFile: URL, to toPath: String, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
+    open func copyItem(localFile: URL, to toPath: String, overwrite: Bool = false, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
+        // TODO: Make use of overwrite parameter
         let opType = FileOperationType.copy(source: localFile.absoluteString, destination: toPath)
         operation_queue.async {
             do {

--- a/Sources/SMBFileProvider.swift
+++ b/Sources/SMBFileProvider.swift
@@ -68,7 +68,7 @@ class SMBFileProvider: FileProvider, FileProviderMonitor {
         return nil
     }
     
-    open func copyItem(localFile: URL, to toPath: String, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
+    open func copyItem(localFile: URL, to toPath: String, overwrite: Bool = false, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
         NotImplemented()
         return nil
     }

--- a/Sources/SMBFileProvider.swift
+++ b/Sources/SMBFileProvider.swift
@@ -68,7 +68,7 @@ class SMBFileProvider: FileProvider, FileProviderMonitor {
         return nil
     }
     
-    open func copyItem(localFile: URL, to toPath: String, overwrite: Bool = false, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
+    open func copyItem(localFile: URL, to toPath: String, overwrite: Bool, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
         NotImplemented()
         return nil
     }

--- a/Sources/WebDAVFileProvider.swift
+++ b/Sources/WebDAVFileProvider.swift
@@ -280,7 +280,7 @@ extension WebDAVFileProvider: FileProviderOperations {
     }
     
     @discardableResult
-    public func copyItem(localFile: URL, to toPath: String, overwrite: Bool = false, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
+    public func copyItem(localFile: URL, to toPath: String, overwrite: Bool, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
         // TODO: Make use of overwrite parameter
         let opType = FileOperationType.copy(source: localFile.absoluteString, destination: toPath)
         guard fileOperationDelegate?.fileProvider(self, shouldDoOperation: opType) ?? true == true else {

--- a/Sources/WebDAVFileProvider.swift
+++ b/Sources/WebDAVFileProvider.swift
@@ -280,7 +280,8 @@ extension WebDAVFileProvider: FileProviderOperations {
     }
     
     @discardableResult
-    public func copyItem(localFile: URL, to toPath: String, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
+    public func copyItem(localFile: URL, to toPath: String, overwrite: Bool = false, completionHandler: SimpleCompletionHandler) -> OperationHandle? {
+        // TODO: Make use of overwrite parameter
         let opType = FileOperationType.copy(source: localFile.absoluteString, destination: toPath)
         guard fileOperationDelegate?.fileProvider(self, shouldDoOperation: opType) ?? true == true else {
             return nil


### PR DESCRIPTION
Added overwrite param to copyItem from local to remote, fixed an issue with file upload on dropbox that wouldnt work for people in non UTC timezones. made filebased upload for dropbox not read file data into memory, let URLSession stream from the disk instead