### PR TITLE
incorrect usage of string.remove in correctPath method, string remove…

### DIFF
--- a/Sources/FileProvider.swift
+++ b/Sources/FileProvider.swift
@@ -219,7 +219,7 @@ extension FileProviderBasic {
         guard let path = path else { return nil }
         var p = path.hasPrefix("/") ? path : "/" + path
         if p.hasSuffix("/") {
-            p.remove(at: p.endIndex)
+            p.remove(at: p.index(before:p.endIndex))
         }
         return p
     }


### PR DESCRIPTION
… needs to be given the index before the endIndex or it will crash