### PR TITLE
Swift 4.2 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9
+osx_image: xcode10
 xcode_project: $PROJECTNAME.xcodeproj
 env:
   global: 

--- a/FilesProvider.podspec
+++ b/FilesProvider.podspec
@@ -65,7 +65,7 @@ Pod::Spec.new do |s|
   #  the deployment target. You can optionally include the target after the platform.
   #
 
-  s.swift_version = "4.1"
+  s.swift_version = "4.2"
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   # s.watchos.deployment_target = "2.0"

--- a/FilesProvider.xcodeproj/project.pbxproj
+++ b/FilesProvider.xcodeproj/project.pbxproj
@@ -824,6 +824,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mousavian.FilesProvider-iOS";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -854,6 +855,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mousavian.FilesProvider-iOS";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -894,6 +896,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mousavian.FilesProvider-OSX";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -927,6 +930,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mousavian.FilesProvider-OSX";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -963,6 +967,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mousavian.FilesProvider-tvOS";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -996,6 +1001,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mousavian.FilesProvider-tvOS";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VALIDATE_PRODUCT = YES;

--- a/FilesProvider.xcodeproj/xcshareddata/xcschemes/FilesProvider OSX.xcscheme
+++ b/FilesProvider.xcodeproj/xcshareddata/xcschemes/FilesProvider OSX.xcscheme
@@ -28,7 +28,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "79D903501FAB647400D61D31"
+               BuildableName = "FilesProviderTests.xctest"
+               BlueprintName = "FilesProviderTests"
+               ReferencedContainer = "container:FilesProvider.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "799396741D48B80D00086753"
+            BuildableName = "FilesProvider.framework"
+            BlueprintName = "FilesProvider OSX"
+            ReferencedContainer = "container:FilesProvider.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/Sources/FileObject.swift
+++ b/Sources/FileObject.swift
@@ -155,9 +155,17 @@ open class FileObject: NSObject {
 
 extension FileObject {
     open override var hash: Int {
+        #if swift(>=4.2)
+        var hasher = Hasher()
+        hasher.combine(url)
+        hasher.combine(size)
+        hasher.combine(modifiedDate)
+        return hasher.finalize()
+        #else
         let hashURL =  self.url.hashValue
         let hashSize = self.size.hashValue
         return (hashURL << 7) &+ hashURL &+ hashSize
+        #endif
     }
     
     /// Check `FileObject` equality

--- a/Sources/FileObject.swift
+++ b/Sources/FileObject.swift
@@ -154,14 +154,10 @@ open class FileObject: NSObject {
 }
 
 extension FileObject {
-    open override var hashValue: Int {
+    open override var hash: Int {
         let hashURL =  self.url.hashValue
         let hashSize = self.size.hashValue
         return (hashURL << 7) &+ hashURL &+ hashSize
-    }
-    
-    open override var hash: Int {
-        return self.hashValue
     }
     
     /// Check `FileObject` equality

--- a/Sources/HTTPFileProvider.swift
+++ b/Sources/HTTPFileProvider.swift
@@ -506,7 +506,6 @@ open class HTTPFileProvider: NSObject, FileProviderBasicRemote, FileProviderOper
     
     func upload_task(_ targetPath: String, progress: Progress, task: URLSessionTask, operation: FileOperationType,
                      completionHandler: SimpleCompletionHandler) -> Void {
-        var progress = progress
         
         var allData = Data()
         dataCompletionHandlersForTasks[session.sessionDescription!]?[task.taskIdentifier] = { data in
@@ -591,7 +590,7 @@ open class HTTPFileProvider: NSObject, FileProviderBasicRemote, FileProviderOper
                            responseHandler: ((_ response: URLResponse) -> Void)? = nil,
                            stream: OutputStream,
                            completionHandler: @escaping (_ error: Error?) -> Void) -> Progress? {
-        var progress = Progress(totalUnitCount: -1)
+        let progress = Progress(totalUnitCount: -1)
         progress.setUserInfoObject(operation, forKey: .fileProvderOperationTypeKey)
         progress.kind = .file
         progress.setUserInfoObject(Progress.FileOperationKind.downloading, forKey: .fileOperationKindKey)
@@ -640,7 +639,7 @@ open class HTTPFileProvider: NSObject, FileProviderBasicRemote, FileProviderOper
                                        responseHandler: ((_ response: URLResponse) -> Void)? = nil,
                                        progressHandler: @escaping (_ data: Data) -> Void,
                                        completionHandler: @escaping (_ error: Error?) -> Void) -> Progress? {
-        var progress = Progress(totalUnitCount: -1)
+        let progress = Progress(totalUnitCount: -1)
         progress.setUserInfoObject(operation, forKey: .fileProvderOperationTypeKey)
         progress.kind = .file
         progress.setUserInfoObject(Progress.FileOperationKind.downloading, forKey: .fileOperationKindKey)
@@ -677,7 +676,7 @@ open class HTTPFileProvider: NSObject, FileProviderBasicRemote, FileProviderOper
     
     internal func download_file(path: String, request: URLRequest, operation: FileOperationType,
                                   completionHandler: @escaping ((_ tempURL: URL?, _ error: Error?) -> Void)) -> Progress? {
-        var progress = Progress(totalUnitCount: -1)
+        let progress = Progress(totalUnitCount: -1)
         progress.setUserInfoObject(operation, forKey: .fileProvderOperationTypeKey)
         progress.kind = .file
         progress.setUserInfoObject(Progress.FileOperationKind.downloading, forKey: .fileOperationKindKey)

--- a/Sources/OneDriveHelper.swift
+++ b/Sources/OneDriveHelper.swift
@@ -221,7 +221,6 @@ internal extension OneDriveFileProvider {
     private func upload_multipart(url: URL, operation: FileOperationType, size: Int64, range: Range<Int64>? = nil, uploadedSoFar: Int64 = 0,
                                   progress: Progress, dataProvider: @escaping (Range<Int64>) throws -> Data, completionHandler: SimpleCompletionHandler) {
         guard !progress.isCancelled else { return }
-        var progress = progress
         
         let maximumSize: Int64 = 10_485_760 // Recommended by OneDrive documentations and divides evenly by 320 KiB, max 60MiB.
         var request = URLRequest(url: url)

--- a/Tests/FilesProviderTests.swift
+++ b/Tests/FilesProviderTests.swift
@@ -235,8 +235,9 @@ class FilesProviderTests: XCTestCase, FileProviderDelegate {
     
     private func randomData(size: Int = 262144) -> Data {
         var keyData = Data(count: size)
+        let count = keyData.count
         let result = keyData.withUnsafeMutableBytes {
-            SecRandomCopyBytes(kSecRandomDefault, keyData.count, $0)
+            SecRandomCopyBytes(kSecRandomDefault, count, $0)
         }
         if result == errSecSuccess {
             return keyData


### PR DESCRIPTION
The project is now compiled with Swift 4.2.
All warnings from Xcode 10 are addressed and fixed.
The test target has been added as the test environment for macOS.
Tests have been updated to no longer have a multiple access error.