### PR TITLE
Fixed Issue#111: Connection stays open after FTP upload

### DIFF
--- a/Sources/FPSStreamTask.swift
+++ b/Sources/FPSStreamTask.swift
@@ -494,7 +494,7 @@ public class FileProviderStreamTask: URLSessionTask, StreamDelegate {
             }
             let isEOF = inputStream.streamStatus == .atEnd && self.dataReceived.count == 0
             self.dataReceivedLock.unlock()
-            completionHandler(dR, isEOF, dR == nil ? inputStream.streamError : nil)
+            completionHandler(dR, isEOF, dR == nil ? (timedOut ? URLError(.timedOut) : inputStream.streamError) : nil)
         }
     }
     


### PR DESCRIPTION
Fixed a truncated uploaded file.
・After byte data upload was completed, it was necessary to close the data connection.
・In addition, it was necessary to wait for FTP response code 2xx and discard the data connection.

The flow of FTP uploading is described below.
> STOR filepath → (FTP Server)1XX responsed → byte data upload → close data connection → (FTP Server)2XX responsed → discard data connection(deinit)


I checked upload, but not checked download sequence.(I'm sorry, I Don't have much time)