### PR TITLE
Added FTP SSL/TLS session resumption/reuse support

### DIFF
--- a/Sources/FTPHelper.swift
+++ b/Sources/FTPHelper.swift
@@ -211,6 +211,7 @@ internal extension FTPFileProvider {
                 let passiveTask = self.session.fpstreamTask(withHostName: host, port: port)
                 if self.baseURL?.scheme == "ftps" || self.baseURL?.scheme == "ftpes" || self.baseURL?.port == 990 {
                     passiveTask.serverTrustPolicy = task.serverTrustPolicy
+                    passiveTask.reuseSSLSession(task: task)
                     passiveTask.startSecureConnection()
                 }
                 passiveTask.securityLevel = .tlSv1
@@ -256,6 +257,7 @@ internal extension FTPFileProvider {
                 let passiveTask = self.session.fpstreamTask(withHostName: host, port: port)
                 if self.baseURL?.scheme == "ftps" || self.baseURL?.scheme == "ftpes" || self.baseURL?.port == 990 {
                     passiveTask.serverTrustPolicy = task.serverTrustPolicy
+                    passiveTask.reuseSSLSession(task: task)
                     passiveTask.startSecureConnection()
                 }
                 passiveTask.securityLevel = .tlSv1
@@ -278,6 +280,7 @@ internal extension FTPFileProvider {
         let activeTask = self.session.fpstreamTask(withNetService: service)
         if self.baseURL?.scheme == "ftps" || self.baseURL?.port == 990 {
             activeTask.serverTrustPolicy = task.serverTrustPolicy
+            activeTask.reuseSSLSession(task: task)
             activeTask.startSecureConnection()
         }
         activeTask.resume()


### PR DESCRIPTION
[Problem]
[Connection problems with FTPS. "session reuse required" on vsFTPd/pure-ftd/proftpd](https://youtrack.jetbrains.com/issue/WI-18980)

[Resolve]
I referred to the following apple doc: 
[SSLSetPeerID](https://developer.apple.com/documentation/security/1400006-sslsetpeerid?language=objc)
> **Discussion**
> 
> Secure Transport uses the peer ID to match the peer of an SSL session with the peer of a previous session in order to resume an interrupted session. If the peer IDs match, Secure Transport attempts to resume the session with the same parameters as used in the previous session with the same peer.
> 
> The data you provide to this function is treated as an opaque blob by Secure Transport but is compared byte for byte with previous peer ID data values set by the current application. An example of peer ID data is an IP address and port, stored in some caller-private manner. Calling this function is optional but is required if you want the session to be resumable. If you do call this function, you must call it prior to the handshake for the current session.
> 
> You can use the SSLGetPeerID function to retrieve the peer ID data for the current session.